### PR TITLE
Model extension

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -114,7 +114,9 @@ console.log('mongoose version: %s', mongoose.version);
 	var circles = new events.EventEmitter();
 	
 	// Load external schema definitions if any...
-	var schemas = {};
+	var schemas = {},
+		commonSchema = require(path.join(conf.schemaPath, 'common.js'));
+		
 	wrench.readdirSyncRecursive(conf.schemaPath).forEach(function(file) {
 	
 		if (file[0] === '.') {return;}
@@ -124,16 +126,18 @@ console.log('mongoose version: %s', mongoose.version);
 			file = path.join(conf.schemaPath, file);
 			
 			// schema name for the current model...
-			var model = path.basename(file);			
+			var model = path.basename(file);
 			var schema= require(file);
+			
 			schemas[model]= {
 				path: file,
-				collection: schema.collection,
-				schema: schema.definition,
-				funcs: schema.funcs || {},
+				collection: schema.collection || '',
+				schema: schema.definition || {},				
+				funcs: extend(schema.funcs || {}, commonSchema.funcs),
+				globals: schema.globals || {},
 				options: schema.options || {},
 				columns: schema.columns || {},
-			};
+			};			
 		}
 	});
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-models",
-  "version": "0.3.2",
+  "version": "0.3.1",
   "description": "A extension to mongoose's models",
   "main": "lib/index.js",
   "scripts": {
@@ -19,7 +19,7 @@
   "author": "marco",
   "license": "MIT",
   "dependencies": {
-    "mongoose": "3.6.19",
+    "mongoose": "3.8.4",
     "wrench": "~1.3.9",
     "mongoose-types": "marco48/mongoose-types",
     "uuid-v4": "~0.1.0",


### PR DESCRIPTION
Add collection name support on model creation by adding a new key in the schema properties.

Extend mongoose model to handle paginate method.
